### PR TITLE
Added fbjs to jest unmockedModulePathPatterns

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     ],
     "unmockedModulePathPatterns": [
       "react",
-      "jquery"
+      "jquery",
+      "fbjs"
     ],
     "collectCoverage": true
   },


### PR DESCRIPTION
I was getting this Runtime Error in the `jest-cli` for `CartItem-test.js` and `LocalizationBox-test.js`: `Cannot read property 'topCompositionEnd' of undefined`

Adding `fbjs` to the `unmockedModulePathPatterns` array in `package.json` seemed to fix this error, and now all five tests are passing.

Related issue from Facebook Jest repo: https://github.com/facebook/jest/issues/558